### PR TITLE
Makefile: use CC variable instead of hardcoded gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ driver_clean:
 app_clean:
 	@rm -f semautil wdogtest app/*.o lib/*.o lib/*.so
 
-semautil: $(APP_OBJS)
-	@$(CC) -g -o $@ $^ -Llib -lsema -luuid
+semautil: libsema.so $(APP_OBJS)
+	@$(CC) -g -o $@ $(APP_OBJS) -Llib -lsema -luuid
 
 wdogtest: $(WDOG_OBJS)
 	@$(CC) $^ -g -o $@

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: libsema.so semautil wdogtest modules
 driver: modules
 
 libsema.so: $(SEMA_OBJS)
-	@gcc -shared -fPIC -g -o lib/$@ $^
+	@$(CC) -shared -fPIC -g -o lib/$@ $^
 
 modules:
 	@make -C /lib/modules/`uname -r`/build M=`pwd` $@
@@ -91,16 +91,16 @@ app_clean:
 	@rm -f semautil wdogtest app/*.o lib/*.o lib/*.so
 
 semautil: $(APP_OBJS)
-	@gcc -g -o $@ $^ -Llib -lsema -luuid
+	@$(CC) -g -o $@ $^ -Llib -lsema -luuid
 
 wdogtest: $(WDOG_OBJS)
-	@gcc $^ -g -o $@
+	@$(CC) $^ -g -o $@
 
 lib/%.o: lib/%.c
-	@gcc -Wall -I lib -g -fPIC -c $< -o $@
+	@$(CC) -Wall -I lib -g -fPIC -c $< -o $@
 
 app/%.o: app/%.c
-	@gcc -Wall -I lib -g -fPIC -c $< -o $@
+	@$(CC) -Wall -I lib -g -fPIC -c $< -o $@
 
 watchdogtest/%.o: watchdogtest/%.c
-	@gcc -Wall -I lib -g -fPIC -c $< -o $@
+	@$(CC) -Wall -I lib -g -fPIC -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
+DESTDIR ?=
+PREFIX ?= /usr
+
 SEMA_OBJS = $(patsubst %.c,%.o,$(wildcard lib/*.c))
 WDOG_OBJS = $(patsubst %.c,%.o,$(wildcard watchdogtest/*.c))
 APP_OBJS = $(patsubst %.c,%.o,$(wildcard app/*.c))
@@ -77,8 +80,9 @@ driver_install:
 	@depmod -a
 
 app_install:
-	@cp lib/libsema.so /usr/lib
-	@cp wdogtest semautil /usr/bin
+	@install -d $(DESTDIR)$(PREFIX)/lib $(DESTDIR)$(PREFIX)/bin
+	@install -m 755 lib/libsema.so $(DESTDIR)$(PREFIX)/lib
+	@install -m 755 wdogtest semautil $(DESTDIR)$(PREFIX)/bin
 
 driver_clean:
 	@make -C /lib/modules/`uname -r`/build M=`pwd` clean

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,14 @@ DIR2 = /lib/modules/$(shell uname -r)/extra
 
 adl-ec-nvmem-sec-m := driver/adl-ec-nvmem-sec.o driver/nvmem-common.o	 
 adl-ec-nvmem-m := driver/adl-ec-nvmem.o driver/nvmem-common.o	 
-all: libsema.so semautil wdogtest modules
+all: app_build modules
 
 driver: modules
 
 libsema.so: $(SEMA_OBJS)
 	@$(CC) -shared -fPIC -g -o lib/$@ $^
+
+app_build: libsema.so semautil wdogtest
 
 modules:
 	@make -C /lib/modules/`uname -r`/build M=`pwd` $@


### PR DESCRIPTION
Allow the compiler to be overridden via the CC variable for cross-compilation support.